### PR TITLE
Django 3-2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ setup(name="omero-virtual-microscope",
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'omero-web>=5.6.0,<5.14.0',
-          'Django>=1.11,<2.0',
+          'omero-web>=5.6.0',
       ],
       python_requires='>=3',
       )


### PR DESCRIPTION
App works fine with https://github.com/ome/omero-web/pull/356 - just removed the requirement `'Django>=1.11,<2.0'`

To test:
 - login
 - Should be redirected to 'courses' page (where Groups are listed as courses)
